### PR TITLE
Feature/fix  tile icons not centered

### DIFF
--- a/src/components/MenuTile.vue
+++ b/src/components/MenuTile.vue
@@ -4,12 +4,13 @@
       <v-card-title class="justify-center">
           <v-icon size="75">{{ icon }}</v-icon>
       </v-card-title>
-      <v-card-text class="text-center display-1 font-weight-medium white--text">{{ text }}</v-card-text>
-      <div v-if="notif == 1">
-        <v-chip color="red" ripple=false label="Notification">{{ notif }} notification</v-chip>
-      </div>
-      <div v-else-if="notif > 1">
-        <v-chip color="red" ripple=false label="Notification">{{ notif }} notifications</v-chip>
+      <v-card-text class="text-center display-1 font-weight-medium white--text">
+        {{ text }}
+      </v-card-text>
+      <div v-if="notif >= 1">
+        <v-chip color="red" ripple=false label="Notification">
+          {{ notif }} notification{{ notif === 1 ? '' : 's' }}
+        </v-chip>
       </div>
     </v-card>
   </router-link>

--- a/src/components/MenuTile.vue
+++ b/src/components/MenuTile.vue
@@ -1,6 +1,6 @@
 <template>
   <router-link :to="link">
-    <v-card align="center" min-height=225 dark :color="color" hover>
+    <v-card class="d-flex flex-column justify-center" align="center" min-height=225 dark :color="color" hover>
       <v-card-title class="justify-center">
           <v-icon size="75">{{ icon }}</v-icon>
       </v-card-title>


### PR DESCRIPTION
## Fix hub menu tile icons not centered:

![image](https://user-images.githubusercontent.com/22414709/80729049-fc2c1200-8b07-11ea-87f1-25e9d5b9cf74.png)

fixes #16 

